### PR TITLE
fix gitignore and add makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.vscode
-.vs
-x64
+.vscode/
+.vs/
+x64/
 21APCS1.txt

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,0 +1,2 @@
+public:
+	g++ ../main.cpp ../user.cpp ../functions.cpp ../course.cpp ../CustomTime.cpp ../COURSE_MANAGEMENT.cpp -o CS162Project.exe


### PR DESCRIPTION
Use 'cd build' and 'mingw32-make' to run the Makefile, the built exe will be exported within the build folder